### PR TITLE
コンテナ判別器

### DIFF
--- a/has_iterator.hpp
+++ b/has_iterator.hpp
@@ -18,6 +18,7 @@ namespace matsulib
 	struct has_iterator : public _detail::IteratorChecker
 	{
 	public:
-		static constexpr auto value = decltype(check <_T>(nullptr))::value;
+		using type = decltype(check <_T>(nullptr));
+		static constexpr auto value = type::value;
 	};
 }

--- a/has_iterator.hpp
+++ b/has_iterator.hpp
@@ -1,5 +1,5 @@
 ﻿#pragma once
-#include <type_traits>
+
 namespace matsulib
 {
 	namespace _detail

--- a/has_iterator.hpp
+++ b/has_iterator.hpp
@@ -1,0 +1,25 @@
+﻿#pragma once
+#include <type_traits>
+namespace matsulib
+{
+	namespace _detail
+	{
+		struct IteratorChecker
+		{
+		protected:
+			struct True { static constexpr bool value = true; };
+			struct False { static constexpr bool value = false; };
+
+		protected:
+			template <class _T> static constexpr auto check(typename _T::iterator*)->True;
+			template <class _T> static constexpr auto check(...)->False;
+		};
+	}
+	
+	template <class _T>
+	struct has_iterator : public _detail::IteratorChecker
+	{
+	public:
+		static constexpr auto value = decltype(check <_T>(nullptr))::value;
+	};
+}

--- a/has_iterator.hpp
+++ b/has_iterator.hpp
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include <type_traits>
+
 namespace matsulib
 {
 	namespace _detail
@@ -7,12 +9,8 @@ namespace matsulib
 		struct IteratorChecker
 		{
 		protected:
-			struct True { static constexpr bool value = true; };
-			struct False { static constexpr bool value = false; };
-
-		protected:
-			template <class _T> static constexpr auto check(typename _T::iterator*)->True;
-			template <class _T> static constexpr auto check(...)->False;
+			template <class _T> static constexpr auto check(typename _T::iterator*) -> std::true_type;
+			template <class _T> static constexpr auto check(...) -> std::false_type;
 		};
 	}
 	


### PR DESCRIPTION
# 概要
`<type_trails>`にイテレータ判別器がなかったので実装した

# 実装
- [x] テンプレ引数にとったクラスがiteratorメンバを持っているかどうか判別する